### PR TITLE
Cleaner sh syntax for checking tags existence

### DIFF
--- a/actions/post-deploy/entrypoint.sh
+++ b/actions/post-deploy/entrypoint.sh
@@ -5,7 +5,7 @@ if [ -n "$GITHUB_WORKSPACE" ]; then
   cd "$GITHUB_WORKSPACE" || exit
 fi
 
-if [[ $(git describe --abbrev=0 --tags 2> /dev/null) -eq 0 ]]; then
+if ! git describe --abbrev=0 --tags &>/dev/null; then
   FIRST_COMMIT=$(git rev-list --max-parents=0 HEAD)
   git tag "CD_autocreate_tag" $FIRST_COMMIT
   echo "No tags found. Created one on the initial commit"


### PR DESCRIPTION
Denne PR fikser feilmelding av denne typen i post-deploy action:
```
/entrypoint.sh: line 8: [[: 20.121.115600: syntax error: invalid arithmetic operator (error token is ".121.115600")
```
