### PR TITLE
Set Java distribution by input. Change default to temurin.

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: "teampam"
+      JAVA_DISTRIBUTION:
+        required: false
+        type: string
+        default: "temurin"
       JAVA_VERSION:
         required: false
         type: string
@@ -57,7 +61,7 @@ jobs:
         if: ${{ inputs.LANGUAGE == 'java' }}
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           java-version: ${{ inputs.JAVA_VERSION }}
           cache: ${{ inputs.BUILD_CACHE }}
       - name: Setup Node

--- a/.github/workflows/deploy-feature-branch.yml
+++ b/.github/workflows/deploy-feature-branch.yml
@@ -9,6 +9,10 @@ on:
         required: false
         type: boolean
         default: true
+      JAVA_DISTRIBUTION:
+        required: false
+        type: string
+        default: "temurin"
       JAVA_VERSION:
         required: false
         type: string
@@ -42,7 +46,7 @@ jobs:
         if: ${{ inputs.LANGUAGE == 'java' }}
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           java-version: ${{ inputs.JAVA_VERSION }}
           cache: ${{ inputs.BUILD_CACHE }}
       - name: Setup Node


### PR DESCRIPTION
* Allow Java distribution to be set by input.
* Change the default from `zulu` to `temurin`, since `temurin` is the build used in the `navikt` base images.