### PR TITLE
Legger tilbake SNYK_TOKEN som optional secret for å ikke brekke bakoverkompabilitet

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -44,6 +44,8 @@ on:
     secrets:
       NAIS_DEPLOY_APIKEY:
         required: true
+      SNYK_TOKEN:
+        required: false
       OPTIONAL_SECRET:
         required: false
       NAIS_WORKLOAD_IDENTITY_PROVIDER:

--- a/.github/workflows/deploy-feature-branch.yml
+++ b/.github/workflows/deploy-feature-branch.yml
@@ -32,6 +32,8 @@ on:
     secrets:
       NAIS_DEPLOY_APIKEY:
         required: true
+      SNYK_TOKEN:
+        required: false
       OPTIONAL_SECRET:
         required: false
 jobs:


### PR DESCRIPTION
Kan helles fjernes i en ny versjon