### PR TITLE
eksponerer image-navn fra nais docker-build-push

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -60,6 +60,10 @@ on:
         required: true
       CODEQL_EXTERNAL_REPO_TOKEN:
         required: false
+    outputs:
+      image:
+        description: "Image from nais build push action"
+        value: ${{ jobs.deploy-dev.outputs.image }}
 jobs:
   deploy-dev:
     permissions:
@@ -69,6 +73,8 @@ jobs:
       actions: read
     runs-on: ubuntu-latest
     environment: ${{ inputs.CLUSTER }}
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
vi har lyst til å ta ibruk workflowen deres, og da hadde det vært fint å få tak i image-navnet nais/docker-build-push outputter, siden vi bruker det til andre actions