### PR TITLE
Bruker dependency-submission action for gradle og mvn apper

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
       security-events: write
       actions: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup CodeQL
@@ -64,6 +64,12 @@ jobs:
         working-directory: ${{ inputs.WORKING_DIRECTORY }}
         env:
           OPTIONAL_SECRET: ${{ secrets.OPTIONAL_SECRET }}
+      - name: Gradle Dependency Submission
+        if: ${{ inputs.LANGUAGE == 'java' && inputs.BUILD_CACHE == 'gradle'}}
+        uses: gradle/actions/dependency-submission@v3
+      - name: Maven Dependency Submission
+        if: ${{ inputs.LANGUAGE == 'java' && inputs.BUILD_CACHE == 'maven'}}
+        uses: advanced-security/maven-dependency-submission-action@v4
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:


### PR DESCRIPTION
Dependabot sliter med gradle-apper for seg selv, og kan også tidvis trenge hjelp med mvn. Sender eksplisitt dependency-grafer i codeql-jobben som uansett kjører på siden av vanlig deploy. 