### PR TITLE
Sender med GITHUB_TOKEN som ACTIONS_RUNTIME_TOKEN i nais/docker-build-push

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -132,6 +132,8 @@ jobs:
           build_secrets: |
             "optional_secret=${{ secrets.OPTIONAL_SECRET }}"
             "sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}"
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to ${{ inputs.CLUSTER }}
         uses: nais/deploy/actions/deploy@v2
         env:


### PR DESCRIPTION
Er en feil for tiden som gjør at trivy feiler ved henting av sårbarhetsbasen. Dette er en midlertidig fiks til trivy får fikset actionet sitt, ref: https://nav-it.slack.com/archives/C047USS5LKA/p1727177205243689

Virker som om det bare påvirker henting av java-basen, så legger det ikke inn i `deploy-next-js-dev.yml`. 