### PR TITLE
Legger til muligheten til å sende inn VERSION_TAG

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -60,6 +60,9 @@ on:
         required: false
         type: string
         default: "10"
+      VERSION_TAG:
+        required: false
+        type: string
     secrets:
       SNYK_TOKEN:
         required: false
@@ -118,6 +121,7 @@ jobs:
           TEAM: ${{ inputs.TEAM }}
           IMAGE_SUFFIX: ${{ inputs.IMAGE_SUFFIX }}
           DRAFTS_MAX: ${{ inputs.DRAFTS_MAX }}
+          VERSION_TAG: ${{ inputs.VERSION_TAG }}
       - name: docker-build-push
         uses: nais/docker-build-push@v0
         id: docker-build-push

--- a/.github/workflows/deploy-next-js-dev.yml
+++ b/.github/workflows/deploy-next-js-dev.yml
@@ -32,6 +32,9 @@ on:
         required: false
         type: boolean
         default: true
+      VERSION_TAG:
+        required: false
+        type: string
     outputs:
       image:
         description: "Image from nais build push action"
@@ -80,6 +83,7 @@ jobs:
           TEAM: ${{ inputs.TEAM }}
           IMAGE_SUFFIX: ${{ inputs.IMAGE_SUFFIX }}
           DRAFTS_MAX: "10"
+          VERSION_TAG: ${{ inputs.VERSION_TAG }}
       - name: Run lint
         run: npm run lint
       - name: Run prettier


### PR DESCRIPTION
Trengs slik at mono-repo kan kjøre én draft og deploye alle applikasjonene til prod i én release action. 