### PR TITLE
Fjerner bruk av slettet variabel NAIS_MANAGEMENT_PROJECT_ID og NAIS_WORKLOAD_IDENTITY_PROVIDER

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -70,7 +70,7 @@ on:
         required: false
       SENTRY_AUTH_TOKEN:
         required: false
-      NAIS_WORKLOAD_IDENTITY_PROVIDER:
+      NAIS_WORKLOAD_IDENTITY_PROVIDER: # DENNE VARIABELEN EKSISTER IKKE LENGER. KAN FJERNES I NY VERSJON AV PAM-DEPLOY
         required: true
     outputs:
       image:
@@ -117,7 +117,6 @@ jobs:
         uses: navikt/pam-deploy/actions/pre-deploy@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROJECT_ID: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           TEAM: ${{ inputs.TEAM }}
           IMAGE_SUFFIX: ${{ inputs.IMAGE_SUFFIX }}
           DRAFTS_MAX: ${{ inputs.DRAFTS_MAX }}
@@ -128,8 +127,6 @@ jobs:
         with:
           team: ${{ inputs.TEAM }}
           tag: ${{ env.VERSION_TAG }}
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           dockerfile: "${{ inputs.WORKING_DIRECTORY }}Dockerfile"
           image_suffix: ${{ inputs.IMAGE_SUFFIX }}
           build_args: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -71,7 +71,7 @@ on:
       SENTRY_AUTH_TOKEN:
         required: false
       NAIS_WORKLOAD_IDENTITY_PROVIDER: # DENNE VARIABELEN EKSISTER IKKE LENGER. KAN FJERNES I NY VERSJON AV PAM-DEPLOY
-        required: true
+        required: false
     outputs:
       image:
         description: "Image from nais build push action"

--- a/.github/workflows/deploy-next-js-dev.yml
+++ b/.github/workflows/deploy-next-js-dev.yml
@@ -79,7 +79,6 @@ jobs:
         uses: navikt/pam-deploy/actions/pre-deploy@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROJECT_ID: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           TEAM: ${{ inputs.TEAM }}
           IMAGE_SUFFIX: ${{ inputs.IMAGE_SUFFIX }}
           DRAFTS_MAX: "10"
@@ -101,16 +100,12 @@ jobs:
           team: ${{ inputs.TEAM }}
           source: ./.next/static
           destination: /${{github.event.repository.name}}/_next
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
       - name: docker-build-push
         uses: nais/docker-build-push@v0
         id: docker-build-push
         with:
           team: ${{ inputs.TEAM }}
           tag: ${{ env.VERSION_TAG }}
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           image_suffix: ${{ inputs.IMAGE_SUFFIX }}
       - name: Deploy to dev-gcp
         uses: nais/deploy/actions/deploy@v2

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -35,7 +35,6 @@ jobs:
       - name: pre-production
         uses: navikt/pam-deploy/actions/pre-production@v7
         env:
-          PROJECT_ID: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           TEAM: ${{ inputs.TEAM }}
           IMAGE_SUFFIX: ${{ inputs.IMAGE_SUFFIX }}
       - uses: nais/deploy/actions/deploy@v2

--- a/.github/workflows/deploy-rollback.yml
+++ b/.github/workflows/deploy-rollback.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "VERSION_TAG=${{ inputs.VERSION }}" >> $GITHUB_ENV
-          echo "IMAGE=europe-north1-docker.pkg.dev/${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}/${{ inputs.TEAM }}/${{ github.event.repository.name }}:${{ inputs.VERSION }}" >> $GITHUB_ENV
+          echo "IMAGE=europe-north1-docker.pkg.dev/nais-management-233d/${{ inputs.TEAM }}/${{ github.event.repository.name }}:${{ inputs.VERSION }}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/actions/pre-deploy/entrypoint.sh
+++ b/actions/pre-deploy/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 GITHUB_URL="https://api.github.com/repos/$GITHUB_REPOSITORY"
-DOCKER_REPO="europe-north1-docker.pkg.dev/$PROJECT_ID/$TEAM"
+DOCKER_REPO="europe-north1-docker.pkg.dev/nais-management-233d/$TEAM"
 # Checking if too many drafts before starting the deploy
 DRAFTS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$GITHUB_URL/releases?per_page=20" | jq -r '. | map(select(.draft == true)) | length')
 if [[ "$DRAFTS" -gt "$DRAFTS_MAX" ]]; then

--- a/actions/pre-production/entrypoint.sh
+++ b/actions/pre-production/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-DOCKER_REPO="europe-north1-docker.pkg.dev/$PROJECT_ID/$TEAM"
+DOCKER_REPO="europe-north1-docker.pkg.dev/nais-management-233d/$TEAM"
 
 if [ -z "$APPLICATION" ]; then
   APPLICATION=$(echo $GITHUB_REPOSITORY | cut -d "/" -f 2)


### PR DESCRIPTION
Disse variablene er slettet, og bruk av `project_id` i nais-workflows er deprecated (https://nav-it.slack.com/archives/C01DE3M9YBV/p1737982464376109) 

Per nå betyr det at alle deploys feiler fordi vi ender opp med en ugyldig IMAGE-lenke.

Der vi trenger verdien er prosjektet hardkodet, per forslag i tråden. Det er det samme for hele Nav, så det burde ikke skape noen problemer for noen av brukerne av pam-deploy

Siden denne hindrer alle deploys har jeg valgt å ikke fjerne `NAIS_WORKLOAD_IDENTITY_PROVIDER` variablen i `deploy-dev`, for da må ting versjoneres opp, og da kommer alt til å fortsette å feile å deploye med mindre man manuelt bumper.