### PR TITLE
Send med NODE_VERSION til CodeQL fra deploy-next-js-dev

### DIFF
--- a/.github/workflows/deploy-next-js-dev.yml
+++ b/.github/workflows/deploy-next-js-dev.yml
@@ -168,3 +168,4 @@ jobs:
     with:
       LANGUAGE: "node"
       BUILD_CACHE: ${{ inputs.PACKAGE_MANAGER }}
+      NODE_VERSION: ${{ inputs.NODE_VERSION }}


### PR DESCRIPTION
pnpm 11 støtter ikke node < 22, og actions/setup-node@v4 virker å defaulte til Node 20 om den ikke får noe versjon