### PR TITLE
Legg til Dependabot og default-branch-sjekk for draft release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Oslo
+    labels:
+      - dependencies
+    # Group all action updates into a single PR to reduce noise
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -154,7 +154,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Draft release
-        if: ${{ !inputs.SKIP_DRAFT_RELEASE }}
+        if: ${{ !inputs.SKIP_DRAFT_RELEASE && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Endringer
- Legger til `.github/dependabot.yml` for ukentlige oppdateringer av GitHub Actions.
- Oppdaterer `deploy-dev.yml` slik at draft release kun opprettes på repositoryets default branch.