### PR TITLE
chore(ci): pin ufestede action-referanser

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,19 +45,19 @@ jobs:
           queries: security-and-quality
       - name: Setup java
         if: ${{ inputs.LANGUAGE == 'java' }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           java-version: ${{ inputs.JAVA_VERSION }}
           cache: ${{ inputs.BUILD_CACHE }}
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         if: ${{ inputs.BUILD_CACHE == 'pnpm' }}
         with:
           run_install: false
       - name: Setup Node
         if: ${{ inputs.LANGUAGE == 'node' }}
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           cache: ${{ inputs.BUILD_CACHE }}
@@ -75,10 +75,10 @@ jobs:
           READER_TOKEN: ${{ secrets.READER_TOKEN }}
       - name: Gradle Dependency Submission
         if: ${{ inputs.LANGUAGE == 'java' && inputs.BUILD_CACHE == 'gradle'}}
-        uses: gradle/actions/dependency-submission@v6
+        uses: gradle/actions/dependency-submission@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
       - name: Maven Dependency Submission
         if: ${{ inputs.LANGUAGE == 'java' && inputs.BUILD_CACHE == 'maven'}}
-        uses: advanced-security/maven-dependency-submission-action@v5.0.0
+        uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:

--- a/.github/workflows/deploy-dev-test.yml
+++ b/.github/workflows/deploy-dev-test.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Process nais doc
-        uses: navikt/pam-deploy/actions/documentation@v9
+        uses: ./actions/documentation
         env:
           CLUSTER: ${{ inputs.CLUSTER }}
           RESOURCE: ${{ inputs.NAIS_RESOURCE }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -95,23 +95,23 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
         name: Set up Docker Buildx
       - name: Setup java
         if: ${{ inputs.LANGUAGE == 'java' }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           java-version: ${{ inputs.JAVA_VERSION }}
           cache: ${{ inputs.BUILD_CACHE }}
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         if: ${{ inputs.BUILD_CACHE == 'pnpm' && inputs.LANGUAGE == 'node'}}
         with:
           run_install: false
       - name: Setup Node
         if: ${{ inputs.LANGUAGE == 'node' }}
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           cache: ${{ inputs.BUILD_CACHE }}
@@ -124,7 +124,7 @@ jobs:
           OPTIONAL_SECRET: ${{ secrets.OPTIONAL_SECRET }}
           READER_TOKEN: ${{ secrets.READER_TOKEN }}
       - name: Pre-deploy
-        uses: navikt/pam-deploy/actions/pre-deploy@v9
+        uses: ./actions/pre-deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEAM: ${{ inputs.TEAM }}
@@ -168,7 +168,7 @@ jobs:
           RESOURCE: ${{ inputs.NAIS_RESOURCE }}
           VARS: ${{ inputs.NAIS_VARS }}
       - name: Post-deploy
-        uses: navikt/pam-deploy/actions/post-deploy@v9
+        uses: ./actions/post-deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Draft release
@@ -195,7 +195,7 @@ jobs:
       contents: write
       security-events: write
       actions: read
-    uses: navikt/pam-deploy/.github/workflows/codeql.yml@v9
+    uses: ./.github/workflows/codeql.yml
     with:
       LANGUAGE: ${{ inputs.LANGUAGE }}
       JAVA_DISTRIBUTION: ${{ inputs.JAVA_DISTRIBUTION }}

--- a/.github/workflows/deploy-next-js-dev.yml
+++ b/.github/workflows/deploy-next-js-dev.yml
@@ -65,18 +65,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         if: ${{ inputs.PACKAGE_MANAGER == 'pnpm' }}
         with:
           run_install: false
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ inputs.NODE_VERSION }}
           cache: ${{ inputs.PACKAGE_MANAGER }}
       - name: Next.js npm cache
         if: ${{ inputs.PACKAGE_MANAGER == 'npm' }}
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.npm
@@ -94,7 +94,7 @@ jobs:
           npm ci
       - name: Next.js pnpm cache
         if: ${{ inputs.PACKAGE_MANAGER == 'pnpm' }}
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ${{ github.workspace }}/.next/cache
@@ -112,7 +112,7 @@ jobs:
           "$PACKAGE_MANAGER" config set //npm.pkg.github.com/:_authToken "$NPM_AUTH_TOKEN"
           bash -eo pipefail -c "$INSTALL_DEPENDENCIES_COMMAND"
       - name: Pre-deploy
-        uses: navikt/pam-deploy/actions/pre-deploy@v9
+        uses: ./actions/pre-deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEAM: ${{ inputs.TEAM }}
@@ -174,7 +174,7 @@ jobs:
           RESOURCE: ${{ inputs.NAIS_RESOURCE }}
           VARS: ${{ inputs.NAIS_VARS }}
       - name: Post-deploy
-        uses: navikt/pam-deploy/actions/post-deploy@v9
+        uses: ./actions/post-deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Draft release
@@ -202,7 +202,7 @@ jobs:
       contents: write
       security-events: write
       actions: read
-    uses: navikt/pam-deploy/.github/workflows/codeql.yml@v9
+    uses: ./.github/workflows/codeql.yml
     with:
       LANGUAGE: "node"
       BUILD_CACHE: ${{ inputs.PACKAGE_MANAGER }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -43,7 +43,7 @@ jobs:
           ref: ${{ env.VERSION_TAG }}
           persist-credentials: false
       - name: pre-production
-        uses: navikt/pam-deploy/actions/pre-production@v9
+        uses: ./actions/pre-production
         env:
           TEAM: ${{ inputs.TEAM }}
           IMAGE_SUFFIX: ${{ inputs.IMAGE_SUFFIX }}
@@ -54,7 +54,7 @@ jobs:
           RESOURCE: ${{ inputs.NAIS_RESOURCE }}
           VARS: ${{ inputs.NAIS_VARS }}
       - name: post-production
-        uses: navikt/pam-deploy/actions/post-production@v9
+        uses: ./actions/post-production
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE_SUFFIX: ${{ inputs.IMAGE_SUFFIX }}

--- a/.github/workflows/tag-release-actions.yml
+++ b/.github/workflows/tag-release-actions.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           persist-credentials: false
       - name: test pre-deploy
-        uses: navikt/pam-deploy/actions/pre-deploy@v9
+        uses: ./actions/pre-deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: true
@@ -49,12 +49,12 @@ jobs:
           echo $APPLICATION
           echo $DRAFTS_MAX
       - name: test post-deploy
-        uses: navikt/pam-deploy/actions/post-deploy@v9
+        uses: ./actions/post-deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: true
       - name: test post-production
-        uses: navikt/pam-deploy/actions/post-production@v9
+        uses: ./actions/post-production
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: true


### PR DESCRIPTION
## Hvorfor
zizmor rapporterte ufestede action-referanser.

## Endring
Pinnet eksterne actions til commit-SHA og byttet interne `@v9`-referanser til lokale stier.