### PR TITLE
Legg til ventetid for Dependabot-oppdateringer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: monday
       time: "06:00"
       timezone: Europe/Oslo
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
     # Group all action updates into a single PR to reduce noise


### PR DESCRIPTION
## Hvorfor
Zizmor varslet at Dependabot manglet ventetid mellom nye utgivelser og oppdateringsforslag. Uten ventetid kan vi få PR-er med en gang en ny versjon slippes, før eventuelle feil eller sikkerhetsproblemer er oppdaget.

## Hva er gjort
La til `cooldown.default-days: 7` for `github-actions` i `.github/dependabot.yml`.

Dette gir en tryggere håndtering av avhengighetsoppdateringer og svarer ut sikkerhetskommentaren.