### PR TITLE
Fjern job-permissions fra deploy-prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -32,10 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: ${{ inputs.CLUSTER }}
-    permissions:
-      contents: write
-      id-token: write
-      actions: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:


### PR DESCRIPTION
Herdingen i #48 la til en permissions-blokk på deploy-prod-jobben. En reusable workflow kan ikke be om flere rettigheter enn den som kaller gir, så repoer som bare ga contents + id-token feila med `requesting 'actions: read', but is only allowed 'actions: none'` (f.eks. pam-import-api).

Tidligere hadde ikke denne jobben noen permissions-blokk – den arva fra caller. Legger det tilbake sånn at eksisterende v9-repoer ikke brekker. Prod-jobben bruker uansett ingen Actions-API.